### PR TITLE
update services for u16all

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,15 +5,15 @@ Available Services :
 
 1. cassandra 3.11
 2. couchdb 1.6
-3. elasticsearch 5.5.0
-4. memcached 1.4.39
+3. elasticsearch 5.5.1
+4. memcached 1.5.0
 5. mongodb 3.4.6
 6. mysql 5.7.18
-7. neo4j 3.2.2
+7. neo4j 3.2.3
 8. postgres 9.6.3
 9. rabbitmq 3.6.10
-10. redis 3.2.9
-11. rethinkdb 2.3.5
+10. redis 4.0.1
+11. rethinkdb 2.3.6
 12. riak 2.2.3
 13. selenium 3.4.0
 14. sqllite 3.19.3

--- a/version/elasticsearch_5_5_1.sh
+++ b/version/elasticsearch_5_5_1.sh
@@ -14,11 +14,11 @@ rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
 chmod +x /usr/local/bin/gosu
 gosu nobody true
 
-ELASTICSEARCH_VERSION=5.5.0
+ELASTICSEARCH_VERSION=5.5.1
 #setup elasticsearch
 cd /usr/local/
 
-echo "================= Installing ElasticSearch 5.5.0 ==================="
+echo "================= Installing ElasticSearch $ELASTICSEARCH_VERSION  ==================="
 wget https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
 tar xzf elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz -C /usr/local && rm -f elasticsearch-${ELASTICSEARCH_VERSION}.tar.gz
 mv elasticsearch-${ELASTICSEARCH_VERSION} elasticsearch

--- a/version/memcached_1_5_0.sh
+++ b/version/memcached_1_5_0.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -e
 
-MEM_VERSION=1.4.39
+MEM_VERSION=1.5.0
 LIB_VERSION=1.0.18
 
 echo "================= Installing MemCached Prereqs ==================="

--- a/version/neo4j_3_2_3.sh
+++ b/version/neo4j_3_2_3.sh
@@ -1,11 +1,12 @@
 #!/bin/bash -e
 
-echo "=========== Installing neo4j 3.2.2============="
+NEO4J_VERSION=3.2.3
+echo "=========== Installing neo4j $NEO4J_VERSION ============="
 
 
 NEO4J_SHA256=47317a5a60f72de3d1b4fae4693b5f15514838ff3650bf8f2a965d3ba117dfc2
-NEO4J_TARBALL=neo4j-community-3.2.2-unix.tar.gz
-NEO4J_URI=https://neo4j.com/artifact.php?name=neo4j-community-3.2.2-unix.tar.gz
+NEO4J_TARBALL=neo4j-community-"$NEO4J_VERSION"-unix.tar.gz
+NEO4J_URI=https://neo4j.com/artifact.php?name=neo4j-community-"$NEO4J_VERSION"-unix.tar.gz
 
 
 curl --fail --show-error -o ${NEO4J_TARBALL} ${NEO4J_URI} \

--- a/version/redis_4_0_1.sh
+++ b/version/redis_4_0_1.sh
@@ -6,4 +6,4 @@ echo "================= Installing redis-server ==================="
 sudo add-apt-repository ppa:chris-lea/redis-server
 sudo apt-get update
 sudo wget https://redis.io/download
-sudo apt-get install redis-server
+sudo apt-get install redis-server=4:4.0.1-4chl1~xenial1

--- a/version/rethinkdb_2_3.sh
+++ b/version/rethinkdb_2_3.sh
@@ -15,6 +15,6 @@ sudo apt-get install -y \
   libjemalloc-dev
 
 # Install RethinkDB
-wget http://download.rethinkdb.com/apt/pool/xenial/main/r/rethinkdb/rethinkdb_2.3.5~0xenial_amd64.deb
+wget http://download.rethinkdb.com/apt/pool/xenial/main/r/rethinkdb/rethinkdb_2.3.6~0xenial_amd64.deb
 sudo dpkg -i rethinkdb*.deb
 rm rethinkdb*.deb


### PR DESCRIPTION
tested by running services locally in container

upgrades versions for
elasticsearch to 5.5.1  https://github.com/dry-dock/u16all/issues/50
memcached to 1.5.0 https://github.com/dry-dock/u16all/issues/46
neo4j to 3.2.3 https://github.com/dry-dock/u16all/issues/47
redis to 3.2.10 https://github.com/dry-dock/u16all/issues/48
rethinkdb to 2.3.6 https://github.com/dry-dock/u16all/issues/49
