### PR TITLE
fixes keyserver error for u16all

### DIFF
--- a/version/elasticsearch_5_5_1.sh
+++ b/version/elasticsearch_5_5_1.sh
@@ -8,7 +8,7 @@ GOSU_VERSION=1.7
 wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture)"
 wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$(dpkg --print-architecture).asc"
 export GNUPGHOME="$(mktemp -d)"
-gpg --keyserver ha.pool.sks-keyservers.net --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
+gpg --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4
 gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu
 rm -r "$GNUPGHOME" /usr/local/bin/gosu.asc
 chmod +x /usr/local/bin/gosu

--- a/version/mongodb_3_4_6.sh
+++ b/version/mongodb_3_4_6.sh
@@ -1,7 +1,7 @@
 #!/bin/bash -e
 
 echo "================= Installing Mongodb 3.4.6 ==================="
-sudo apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
+sudo apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv 0C49F3730359A14518585931BC711F9BA15703C6
 echo "deb [ arch=amd64,arm64 ] http://repo.mongodb.org/apt/ubuntu xenial/mongodb-org/3.4 multiverse" | sudo tee /etc/apt/sources.list.d/mongodb-org-3.4.list
 sudo apt-get update
 sudo apt-get install -y mongodb-org


### PR DESCRIPTION
https://github.com/dry-dock/u16all/issues/51

fixes failing u16all build due to failure in gpg key validation. as per solution given here: https://github.com/tianon/gosu/issues/17#issuecomment-203074866